### PR TITLE
feat: update styling to match company website

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Provider } from '@containous/faency'
 import { SWRConfig } from 'swr'
 import fetcher from 'utils/fetcher'
 import DrawerGlobalStyle from 'components/nav/DrawerGlobalStyle'
+import FontGlobalStyle from 'components/nav/FontGlobalStyle'
 
 const FaencyProvider = Provider as React.FC<ComponentProps<typeof Provider> & { children: ReactNode }>
 
@@ -17,6 +18,7 @@ function App() {
     >
       <FaencyProvider>
         <DrawerGlobalStyle />
+        <FontGlobalStyle />
         <Header />
       </FaencyProvider>
     </SWRConfig>

--- a/src/components/nav/FontGlobalStyle.ts
+++ b/src/components/nav/FontGlobalStyle.ts
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from 'styled-components'
+
+const FontGlobalStyle = createGlobalStyle`
+  body {
+    font-family: Rubik, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, sans-serif;
+  }
+`
+
+export default FontGlobalStyle

--- a/src/components/nav/MainNav.tsx
+++ b/src/components/nav/MainNav.tsx
@@ -65,7 +65,16 @@ const MainNav: React.FC = () => {
               title="Traefik Hub"
               titleHtml={
                 <Flex sx={{ alignItems: 'center', mt: '12px' }}>
-                  <Heading as="h2" sx={{ fontSize: '20px' }}>
+                  <Heading
+                    as="h2"
+                    sx={{
+                      fontSize: '20px',
+                      fontWeight: 700,
+                      lineHeight: 1.33,
+                      letterSpacing: 0,
+                      fontFamily: 'inherit',
+                    }}
+                  >
                     Traefik Hub
                   </Heading>
                   <Flex
@@ -87,7 +96,7 @@ const MainNav: React.FC = () => {
                         lineHeight: '14px',
                         color: theme.colors.white,
                         fontWeight: 500,
-                        letterSpacing: '2.75px',
+                        letterSpacing: '3.5px',
                       }}
                     >
                       BETA
@@ -160,7 +169,7 @@ const MainNav: React.FC = () => {
           </Grid>
         </NavItem>
 
-        <NavItem name="Solutions" hasSubmenu position={{ right: '25%' }}>
+        <NavItem name="Solutions" hasSubmenu position={{ marginLeft: '-25%' }}>
           <Grid sx={{ gridTemplateColumns: '380px 288px', p: '40px', gap: '40px' }}>
             <MenuColumn.Column title="Solutions">
               <MenuColumn.Item

--- a/src/components/nav/MenuColumn.tsx
+++ b/src/components/nav/MenuColumn.tsx
@@ -41,7 +41,6 @@ const Links = styled.ul`
 
   span {
     font-size: 16px;
-    line-height: 24px;
     font-weight: normal;
     color: #677581;
   }
@@ -54,7 +53,17 @@ type MenuColumnProps = {
 
 export const Column: React.FC<MenuColumnProps> = ({ title, children }) => (
   <Box>
-    <Text as="p" sx={{ mb: '18px', fontSize: '11px', fontWeight: 500, color: '#7e89a7', letterSpacing: '2.75px' }}>
+    <Text
+      as="p"
+      sx={{
+        mb: '14px',
+        fontSize: '11px',
+        fontWeight: 500,
+        lineHeight: 1.33,
+        color: '#7e89a7',
+        letterSpacing: '2.75px',
+      }}
+    >
       {title.toUpperCase()}
     </Text>
     <Links>{children}</Links>
@@ -74,7 +83,7 @@ export const Item: React.FC<MenuColumnLinkProps> = ({ href, external, title, log
     {external ? (
       <Link href={href} target="_self" {...props}>
         {logo ? (
-          <Box sx={{ display: 'flex' }}>
+          <Box sx={{ display: 'flex', paddingTop: '5px' }}>
             {logo}
             <Box sx={{ ml: '15px', maxWidth: '290px' }}>
               <Text as="p">{title}</Text>

--- a/src/components/nav/PostCard.tsx
+++ b/src/components/nav/PostCard.tsx
@@ -8,6 +8,7 @@ const CustomArrowLink = ArrowLink as any
 const CustomImage = styled.img`
   object-fit: cover;
   width: 100%;
+  height: 162px;
   layout: fill;
 `
 
@@ -53,9 +54,10 @@ const PostCard: React.FC<MenuPostCard> = ({ post }) => {
               mb: '16px',
               fontSize: '18px',
               lineHeight: 1.33,
-              flex: 1,
+              letterSpacing: 'normal',
               color: theme.colors.dark,
-              fontWeight: 'medium',
+              fontFamily: 'inherit',
+              fontWeight: 500,
             }}
           >
             {post.title}

--- a/src/components/nav/Product.tsx
+++ b/src/components/nav/Product.tsx
@@ -24,11 +24,21 @@ const Product: React.FC<NavProductProps> = ({ logo, title, titleHtml, descriptio
   <Box sx={{ p: 40, backgroundColor: bgColor || '#fff' }}>
     <Box>{logo}</Box>
     {titleHtml || (
-      <Heading as="h2" sx={{ fontSize: '20px', mt: '12px', fontWeight: 700 }}>
+      <Heading
+        as="h2"
+        sx={{
+          fontSize: '20px',
+          mt: '12px',
+          lineHeight: 1.33,
+          letterSpacing: 0,
+          fontWeight: 700,
+          fontFamily: 'inherit',
+        }}
+      >
         {title}
       </Heading>
     )}
-    <Text as="p" sx={{ fontSize: '16px', mt: 1, color: '#677581' }}>
+    <Text as="p" sx={{ fontSize: '16px', mt: 1, lineHeight: 1.33, color: '#677581' }}>
       {description}
     </Text>
     <ArrowLink url={url} icon="arrow" iconHoverTransform={true} color={color} mt={`10px`}>


### PR DESCRIPTION
There were some small visual differences between the header on this repo and the one on the company website (the reference one).

Now there shouldn't be any difference between them.