### PR TITLE
fix: custom event props to match mkt expectations

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,4 +7,4 @@ registerCustomElement({
   component: App,
 })
 
-addCustomClickEventListener('custom_click_event')
+addCustomClickEventListener('doc_nav_click')

--- a/src/utils/addCustomEventListener.ts
+++ b/src/utils/addCustomEventListener.ts
@@ -27,12 +27,14 @@ export const addCustomClickEventListener = (eventName: string) => {
 
       window.dataLayer.push({
         event: eventName,
-        custom_event: {
+        gtm: {
           element: targetElement,
           elementId: targetElement.id || '',
           elementClasses: targetElement.className || '',
           elementUrl: targetElement.href || targetElement.action || '',
           elementTarget: targetElement.target || '',
+          clickUrl: targetElement.href || targetElement.action || '',
+          clickText: targetElement.textContent || '',
           originalEvent: event,
           inShadowDom: shadowFound,
         },


### PR DESCRIPTION
Requested by Dylan:
The Click Element is "HTMLElement: `html.js-focus-visible.js > body > header-app`" and the `elementURL` that Google sees first is empty (see image attached), but there's another below, it just doesn't pull in it appropriately.

I think to make this work, we have to have the following:
- have the link URL send data to the `clickURL` field (NOT the `elementURL`, which is not a thing in GTM)
- have the text of the menu item be added as a value in the `clickText` field.

Additionally, can we make the custom event be named `doc_nav_click`

