### PR TITLE
fix: Hub tagline to not break lines

### DIFF
--- a/src/components/nav/Product.tsx
+++ b/src/components/nav/Product.tsx
@@ -20,7 +20,7 @@ type NavProductProps = {
   }[]
 }
 
-const Product: React.FC<NavProductProps> = ({ logo, title, titleHtml, description, url, links, color, bgColor }) => (
+const Product = ({ logo, title, titleHtml, description, url, links, color, bgColor }: NavProductProps) => (
   <Box sx={{ p: 40, backgroundColor: bgColor || '#fff' }}>
     <Box>{logo}</Box>
     {titleHtml || (
@@ -38,7 +38,7 @@ const Product: React.FC<NavProductProps> = ({ logo, title, titleHtml, descriptio
         {title}
       </Heading>
     )}
-    <Text as="p" sx={{ fontSize: '16px', mt: 1, lineHeight: 1.33, color: '#677581' }}>
+    <Text as="p" sx={{ fontSize: '16px', mt: 1, lineHeight: 1.33, color: '#677581', whiteSpace: 'nowrap' }}>
       {description}
     </Text>
     <ArrowLink url={url} icon="arrow" iconHoverTransform={true} color={color} mt={`10px`}>


### PR DESCRIPTION
Before
<img width="555" alt="image" src="https://user-images.githubusercontent.com/38889364/230186642-40efd130-f401-4119-9a2b-ff4421cc1dfe.png">

After
<img width="545" alt="image" src="https://user-images.githubusercontent.com/38889364/230186677-c6ae84b4-c261-47d6-9a66-d1ba5d2efd5c.png">
