### PR TITLE
feat: get product attribute to set demo link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import FontGlobalStyle from 'components/nav/FontGlobalStyle'
 
 const FaencyProvider = Provider as React.FC<ComponentProps<typeof Provider> & { children: ReactNode }>
 
-function App() {
+function App({ product }: { product?: string }) {
   return (
     <SWRConfig
       value={{
@@ -19,7 +19,7 @@ function App() {
       <FaencyProvider>
         <DrawerGlobalStyle />
         <FontGlobalStyle />
-        <Header />
+        <Header product={product} />
       </FaencyProvider>
     </SWRConfig>
   )

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { Nav as FaencyNav, NavContainer as FaencyNavContainer, theme, Flex, Box } from '@containous/faency'
 import styled, { createGlobalStyle } from 'styled-components'
 import Logo from 'components/Logo'
@@ -113,9 +113,15 @@ const Hamburger = styled.div`
   }
 `
 
-const Header = () => {
+const Header = ({ product }: { product?: string }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [isHeaderScrolled, setHeaderScrolled] = useState(false)
+
+  const demoLink = useMemo(() => {
+    if (product === 'hub') return 'https://info.traefik.io/traefik-hub-signup'
+
+    return 'https://info.traefik.io/en/request-demo-traefik-enterprise'
+  }, [product])
 
   useEffect(() => {
     const adjustHeaderHeight = function () {
@@ -179,7 +185,7 @@ const Header = () => {
                   </svg>
                 </NavIconButton>
                 <NavButton href="https://info.traefik.io/speak-with-an-expert">Speak with an expert</NavButton>
-                <NavButtonPrimary href="https://info.traefik.io/en/request-demo-traefik-enterprise">
+                <NavButtonPrimary href={demoLink}>
                   Get a Demo
                 </NavButtonPrimary>
               </Flex>


### PR DESCRIPTION
## Description

Add capability for Header component to read `product` attribute to show a different demo link for Hub. If there is no product attribute provided, the link by default will still point to `https://info.traefik.io/en/request-demo-traefik-enterprise`.

Needed for this PR: https://github.com/traefik/doc/pull/1165

- Fixes https://github.com/traefik/hub-issues/issues/674#issuecomment-1515907726