### PR TITLE
chore: upgrade gh actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,12 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
-
-      - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
         run: make deps
@@ -25,4 +27,3 @@ jobs:
 
       - name: Generate assets
         run: make static-assets
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,20 @@ on:
 
 env:
   REACT_APP_POLLING_INTERVAL: 300000
-  REACT_APP_DOCWHIZZ_TRAEFIK_EE_USER_ID: "${{ secrets.DOCWHIZZ_TRAEFIK_EE_USER_ID }}"
-  REACT_APP_DOCWHIZZ_TRAEFIK_PROXY_USER_ID: "${{ secrets.DOCWHIZZ_TRAEFIK_PROXY_USER_ID }}"
 
 jobs:
   doc:
     name: Build and publish assets
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
-
-      - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
         run: make deps
@@ -33,7 +33,7 @@ jobs:
 
       # https://github.com/marketplace/actions/github-pages
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: gh-pages
           build_dir: static-assets


### PR DESCRIPTION
# Motivation

Previous node.js version used by previous version of github actions is deprecated.
I also added cache and removed now unused secrets variable